### PR TITLE
Fix order of link.ports when converting the topology and checking for attributes when updating topology

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
 include kytos.json
-recursive-include requirements *
+include requirements/run.txt

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,17 @@
 """Module with the Constants used in the kytos/sdx."""
 
+# SDXLC_URL: URL to send the topology to SDX-LC
+# you can change the value below or override it using environment variable
+SDXLC_URL = "http://127.0.0.1:8080/SDX-LC/2.0.0/topology"
+
+# OXPO_NAME: Open Exchange Point Name
+# you can change the value below or override it using environment variable
+OXPO_NAME = "TestOXP"
+
+# OXPO_URL: OXP URL
+# you can change the value below or override it using environment variable
+OXPO_URL = "testoxp.net"
+
 # TOPOLOGY_EVENT_WAIT: time to wait while hanlde topology update
 # events to try to group them
 TOPOLOGY_EVENT_WAIT=5

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,16 +3,18 @@ max-line-length = 88
 exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
+radon mi args = --min C
 pylint args = --disable=too-few-public-methods,too-many-instance-attributes,unnecessary-pass,raise-missing-from
-linters=pylint,pycodestyle,isort,black
+linters=pylint,pycodestyle,isort
 
-[flake8]
-max-line-length = 88
+[pydocstyle]
+add-ignore = D105,D107
+# D105: Missing docstring in magic method
+# D107: Missing docstring in __init__
+# W0201: Attribute defined outside init
 
 [isort]
 profile = black
 # The first party was necessary to fix travis build.
 known_first_party = kytos.core,tests,napps
 known_third_party = pyof
-# Ignoring tests because is adding napps path
-skip=tests


### PR DESCRIPTION

## Description of the changes

This PR adds the following fixes/enhancements:

- Fixed the order of link.ports and link.id creation: before a link could be created with non deterministic order, resulting on different links being exported and leading to inconsistent comparison (ex: `urn:sdx:link:testoxp.net:TestSw2/3_TestSw3/3` and `urn:sdx:link:testoxp.net:TestSw2/3_TestSw2/3`)
- Added checks for object attributes when updating the topology, specially for `Interface.nni`, `Interface.link` and `Interface.speed` to update the attribute and export the correct value
- Adding new configuration parameters to `settings.py` for SDXLC_URL, OXPO_NAME and OXPO_URL, to allow static configuration as an alternative for environment variables
- Minor adjustments on `setup.cfg` and `MANIFEST.in`