### PR TITLE
Fix coverage omit dirs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 source = .
-omit = .eggs/*,.tox/*,*tests*,setup.py,.direnv/*,venv/*,.venv/*
+omit = .eggs/*,.tox/*,tests/*,setup.py,.direnv/*,venv/*,.venv/*
 
 [report]
 show_missing = True


### PR DESCRIPTION
This PR fixes an issue identified by @gretelliz, in which the coverage report was including the tests directory. 