### PR TITLE
Add sanity check to avoid sending empty topology to SDX-LC

### DIFF
--- a/main.py
+++ b/main.py
@@ -382,6 +382,8 @@ class Main(KytosNApp):  # pylint: disable=R0904
     @rest("topology/2.0.0", methods=["GET"])
     def get_sdx_topology_v2(self, _request: Request) -> JSONResponse:
         """return sdx topology v2"""
+        if not self._converted_topo.get("nodes"):
+            return JSONResponse(status_code=204)
         return JSONResponse(self._converted_topo)
 
     @rest("topology/2.0.0", methods=["POST"])

--- a/main.py
+++ b/main.py
@@ -383,7 +383,7 @@ class Main(KytosNApp):  # pylint: disable=R0904
     def get_sdx_topology_v2(self, _request: Request) -> JSONResponse:
         """return sdx topology v2"""
         if not self._converted_topo.get("nodes"):
-            return None
+            return JSONResponse({}, status_code=204)
         return JSONResponse(self._converted_topo)
 
     @rest("topology/2.0.0", methods=["POST"])

--- a/main.py
+++ b/main.py
@@ -383,7 +383,7 @@ class Main(KytosNApp):  # pylint: disable=R0904
     def get_sdx_topology_v2(self, _request: Request) -> JSONResponse:
         """return sdx topology v2"""
         if not self._converted_topo.get("nodes"):
-            return JSONResponse(status_code=204)
+            return None
         return JSONResponse(self._converted_topo)
 
     @rest("topology/2.0.0", methods=["POST"])

--- a/main.py
+++ b/main.py
@@ -383,7 +383,7 @@ class Main(KytosNApp):  # pylint: disable=R0904
     def get_sdx_topology_v2(self, _request: Request) -> JSONResponse:
         """return sdx topology v2"""
         if not self._converted_topo.get("nodes"):
-            return JSONResponse({}, status_code=204)
+            return JSONResponse({}, status_code=200)
         return JSONResponse(self._converted_topo)
 
     @rest("topology/2.0.0", methods=["POST"])


### PR DESCRIPTION
This pull request adds a sanity check to avoid sending empty topology to SDX-LC when it is pulling for the topology.