### PR TITLE
fix: topology request during setup is blocking the MainThread, hanging until timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,4 +20,4 @@ Changed
 
 Fixed
 =====
--
+- Avoid blocking setup() when loading topology

--- a/main.py
+++ b/main.py
@@ -88,6 +88,9 @@ class Main(KytosNApp):  # pylint: disable=R0904
                 "version": 1,
                 "timestamp": get_timestamp(),
             }
+
+    def load_kytos_topology(self):
+        """Load topology from Kytos-ng."""
         with self._topo_lock:
             self._topo_dict = self.get_kytos_topology()
             self._converted_topo = self.convert_topology_v2()
@@ -111,10 +114,15 @@ class Main(KytosNApp):  # pylint: disable=R0904
             )
         return topology
 
-    @listen_to(
-        "kytos/topology.updated",
-        "kytos/topology.topology_loaded",
-    )
+    @listen_to("kytos/topology.topology_loaded")
+    def on_topology_loaded(self, event: KytosEvent):
+        """Handler for on topology_loaded."""
+        self.handler_on_topology_loaded()
+
+    def handler_on_topology_loaded(self):
+        self.load_kytos_topology()
+
+    @listen_to("kytos/topology.updated")
     def on_topology_updated_event(self, event: KytosEvent):
         """Handler for topology updated events."""
         self.handler_on_topology_updated_event(event)

--- a/main.py
+++ b/main.py
@@ -115,11 +115,12 @@ class Main(KytosNApp):  # pylint: disable=R0904
         return topology
 
     @listen_to("kytos/topology.topology_loaded")
-    def on_topology_loaded(self, event: KytosEvent):
+    def on_topology_loaded(self, _event: KytosEvent):
         """Handler for on topology_loaded."""
         self.handler_on_topology_loaded()
 
     def handler_on_topology_loaded(self):
+        """Hnalder on_topology_loaded."""
         self.load_kytos_topology()
 
     @listen_to("kytos/topology.updated")

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ class Main(KytosNApp):  # pylint: disable=R0904
         self.handler_on_topology_loaded()
 
     def handler_on_topology_loaded(self):
-        """Hnalder on_topology_loaded."""
+        """Handler on_topology_loaded."""
         self.load_kytos_topology()
 
     @listen_to("kytos/topology.updated")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -115,6 +115,15 @@ class TestMain:
         assert response.status_code == 201
         assert response.json() == {"service_id": "a123"}
 
+    def test_handler_on_topology_loaded(self):
+        """Test handler_on_topology_loaded."""
+        self.napp.get_kytos_topology = MagicMock()
+        some_topo = {"switches": {"dpid1": {}}, "links": {"link1": {}}}
+        self.napp.get_kytos_topology.return_value = some_topo
+        self.napp.convert_topology_v2 = MagicMock()
+        self.napp.handler_on_topology_loaded()
+        assert self.napp._topo_dict == some_topo
+
     @patch("requests.post")
     @patch("requests.patch")
     async def test_update_l2vpn(self, req_patch_mock, req_post_mock):


### PR DESCRIPTION
Closes #75 

### Summary

- Avoid blocking setup() when loading topology by moving it to handle `kytos/topology.topology_loaded`

### Local Tests

- Loaded this NApp and observed `kytos/topology.topology_loaded` and `kytos/topology.updated`, it loaded correctly without also the request timeout on `setup()`

```

2024-11-07 13:41:38,541 - INFO [kytos.core.controller] (MainThread) Loading NApp kytos/sdx
2024-11-07 13:41:38,542 - INFO [kytos.core.napps.base] (of_multi_table) Running NApp: <Main(of_multi_table, started 140441320150720)>
2024-11-07 13:41:38,555 - INFO [kytos.core.napps.base] (sdx) Running NApp: <Main(sdx, started 140441311758016)>
2024-11-07 13:41:38,556 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/sdx/topology/2.0.0 - GET
2024-11-07 13:41:38,556 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/sdx/topology/2.0.0 - POST
2024-11-07 13:41:38,557 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/sdx/l2vpn/1.0 - POST
2024-11-07 13:41:38,557 - INFO [kytos.core.api_server] (MainThread) Started /api/kytos/sdx/l2vpn/1.0/{service_id} - PATCH



kytos $> assert controller.napps[('kytos', 'sdx')]._topo_dict["links"]

kytos $> assert controller.napps[('kytos', 'sdx')]._converted_topo["links"]

kytos $> controller.napps[('kytos', 'sdx')].sdx_topology
Out[5]: 
{'_id': 'topology',
 'timestamp': '2024-11-07T16:41:43Z',
 'updated_at': datetime.datetime(2024, 11, 7, 16, 41, 43, 635379),
 'version': 3}

```

### End-to-End Tests

N/A
