### PR TITLE
Fix VLAN range transformation from L2VPN format into Kytos Mef_Eline

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,6 +142,9 @@ Create L2VPN with new API
 	# Example 04: example with all possible attributes
 	curl -s -X POST -H 'Content-type: application/json' http://127.0.0.1:8181/api/kytos/sdx/l2vpn/1.0 -d '{"name": "AMPATH_vlan_503_503", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "501"}, {"port_id": "urn:sdx:port:ampath.net:Ampath1:40", "vlan": "501"}], "description": "test foobar xpto aa bbb", "scheduling": {"start_time": "2024-08-07T19:55:00Z", "end_time": "2024-08-07T19:58:00Z"}, "notifications": [{"email": "user@domain.com"},{"email": "user2@domain2.com"}], "qos_metrics": {"min_bw": {"value": 5,"strict": false}, "max_delay": {"value": 150, "strict": true}}}'
 
+	# Example 05: minimal attributes with endpoint.0 being untagged (frames without 802.1q header)
+	curl -s -X POST -H 'Content-type: application/json' http://127.0.0.1:8181/api/kytos/sdx/l2vpn/1.0 -d '{"name": "AMPATH_vlan_untagged_503", "endpoints": [{"port_id": "urn:sdx:port:ampath.net:Ampath3:50", "vlan": "untagged"}, {"port_id": "urn:sdx:port:ampath.net:Ampath1:40", "vlan": "503"}]}'
+
 
 Edit L2VPN with new API
 *************************

--- a/main.py
+++ b/main.py
@@ -613,7 +613,7 @@ class Main(KytosNApp):  # pylint: disable=R0904
         # "any" -> Not Supported! the OXPO wont choose the VLAN, not supported
         # "untagged" -> untagged: no conversion
         # "xx:yy" -> [xx, yy]: VLAN range
-        if sdx_vlan.isdigit() or isinstance(sdx_vlan, int):
+        if isinstance(sdx_vlan, int) or sdx_vlan.isdigit():
             sdx_vlan = int(sdx_vlan)
             if sdx_vlan < 1 or sdx_vlan > 4095:
                 return None, f"Invalid vlan {sdx_vlan} on endpoint (0 > vlan < 4096)"

--- a/main.py
+++ b/main.py
@@ -731,6 +731,12 @@ class Main(KytosNApp):  # pylint: disable=R0904
 
         kuni_a = self.sdx2kytos.get(uni_a)
         kuni_z = self.sdx2kytos.get(uni_z)
+        kvlan_a, _ = self.parse_vlan(vlan_a)
+        kvlan_z, _ = self.parse_vlan(vlan_z)
+        if not all([kuni_a, kvlan_a, kuni_z, kvlan_z]):
+            msg = "Delete EVC failed: invalid attribute."
+            log.warn(f"{msg}: {kuni_a=} {kvlan_a=} {kuni_z=} {kvlan_z=}")
+            return JSONResponse({"result": msg}, 400)
 
         try:
             response = requests.get(KYTOS_EVC_URL, timeout=30)
@@ -747,9 +753,9 @@ class Main(KytosNApp):  # pylint: disable=R0904
             if all(
                 [
                     evc["uni_a"]["interface_id"] == kuni_a,
-                    evc["uni_a"].get("tag", {}).get("value") == vlan_a,
+                    evc["uni_a"].get("tag", {}).get("value") == kvlan_a,
                     evc["uni_z"]["interface_id"] == kuni_z,
-                    evc["uni_z"].get("tag", {}).get("value") == vlan_z,
+                    evc["uni_z"].get("tag", {}).get("value") == kvlan_z,
                 ]
             ):
                 break

--- a/main.py
+++ b/main.py
@@ -633,6 +633,7 @@ class Main(KytosNApp):  # pylint: disable=R0904
                 assert 1 <= sdx_vlan[1] <= 4095
             except (AttributeError, ValueError, AssertionError):
                 return None, f"Invalid vlan range on endpoint ({sdx_vlan})"
+            sdx_vlan = [sdx_vlan]
         return sdx_vlan, None
 
     @rest("l2vpn/1.0/{service_id}", methods=["DELETE"])

--- a/main.py
+++ b/main.py
@@ -691,10 +691,11 @@ class Main(KytosNApp):  # pylint: disable=R0904
                         msg_err = f"Invalid VLAN for L2VPN creation: {msg}"
                         log.warn(f"{msg_err} -- request={content}")
                         raise HTTPException(400, detail=msg_err)
-                    evc_dict[attr]["tag"] = {
-                        "tag_type": "vlan",
-                        "value": sdx_vlan,
-                    }
+                    if sdx_vlan:
+                        evc_dict[attr]["tag"] = {
+                            "tag_type": "vlan",
+                            "value": sdx_vlan,
+                        }
             elif attr == "name":
                 evc_dict[attr] = self.name_prefix + content[attr]
             else:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -311,6 +311,24 @@ class TestMain:
         assert response.status_code == 200
         assert response.json() == {"circuit_id": "a123"}
 
+        # test 2: invalid payload
+        payload["uni_a"]["tag"]["value"] = "invalid"
+        response = await self.api_client.post(
+            f"{self.endpoint}/v1/l2vpn_ptp",
+            json=payload,
+        )
+        assert response.status_code == 400
+
+        # test 3: testing with VLAN 'all'
+        payload["uni_a"]["tag"]["value"] = "all"
+        response = await self.api_client.post(
+            f"{self.endpoint}/v1/l2vpn_ptp",
+            json=payload,
+        )
+        assert response.status_code == 200
+        requests_mock.assert_called_with(json={})
+
+
     @patch("requests.get")
     @patch("requests.delete")
     async def test_delete_l2vpn_old_api(self, req_del_mock, req_get_mock):

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -374,7 +374,7 @@ class TestMain:
         assert msg is None
         # case 4: range - valid
         vlan, msg = self.napp.parse_vlan("1:100")
-        assert vlan == [1, 100]
+        assert vlan == [[1, 100]]
         assert msg is None
         # case 5: range - invalid
         vlan, msg = self.napp.parse_vlan("1:9999")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -133,7 +133,8 @@ class TestMain:
         assert unordered(converted_topo["links"]) == expected["links"]
 
     @patch("time.sleep", return_value=None)
-    def test_update_topology_metadata_success_case(self, _):
+    @patch("napps.kytos.sdx.main.log.warning")
+    def test_update_topology_metadata(self, log_mock, _):
         """Test update metadata method to success case."""
         self.napp._topo_dict = get_topology_dict()
         self.napp.sdx_topology = {"version": 1, "timestamp": "2024-07-18T15:33:12Z"}
@@ -188,6 +189,16 @@ class TestMain:
         )
         assert res_link["residual_bandwidth"] == 90
 
+        # Test 4: invalid interface metadata
+        interface._id = "aa:00:00:00:00:00:00:02:999"
+        event = KytosEvent(
+            name="kytos/topology.interfaces.metadata.added",
+            content={"interface": interface, "metadata": interface.metadata.copy()},
+        )
+        log_mock.call_count = 0
+        self.napp.handle_metadata_event(event)
+        log_mock.assert_called()
+
     async def test_get_topology_response(self):
         """Test shortest path."""
         self.napp.controller.loop = asyncio.get_running_loop()
@@ -235,6 +246,32 @@ class TestMain:
         assert response.status_code == 201
         assert response.json() == {"service_id": "a123"}
 
+        # Test 2: invalid endpoints
+        endpoint2 = payload["endpoints"].pop()
+        response = await self.api_client.post(
+            f"{self.endpoint}/l2vpn/1.0",
+            json=payload,
+        )
+        assert response.status_code == 402
+
+        # Test 3: invalid request payload
+        payload["endpoints"].append(endpoint2)
+        payload["endpoints"][1]["port_id"] = "urn:sdx:port:testoxp.net:TestSw3:9999"
+        response = await self.api_client.post(
+            f"{self.endpoint}/l2vpn/1.0",
+            json=payload,
+        )
+        assert response.status_code == 400
+
+        # Test 4: failed to submit request to mef_eline
+        payload["endpoints"][1]["port_id"] = "urn:sdx:port:testoxp.net:TestSw3:50"
+        requests_mock.return_value.status_code = 400
+        response = await self.api_client.post(
+            f"{self.endpoint}/l2vpn/1.0",
+            json=payload,
+        )
+        assert response.status_code == 400
+
     def test_handler_on_topology_loaded(self):
         """Test handler_on_topology_loaded."""
         self.napp.get_kytos_topology = MagicMock()
@@ -268,6 +305,23 @@ class TestMain:
         )
         assert response.status_code == 201
 
+        # Test 2: invalid request payload
+        payload["endpoints"][1]["port_id"] = "urn:sdx:port:testoxp.net:TestSw1:9999"
+        response = await self.api_client.patch(
+            f"{self.endpoint}/l2vpn/1.0/a123",
+            json=payload,
+        )
+        assert response.status_code == 400
+
+        # Test 3: failed to submit request to Kytos
+        payload["endpoints"][1]["port_id"] = "urn:sdx:port:testoxp.net:TestSw1:40"
+        req_patch_mock.return_value = MagicMock(status_code=400)
+        response = await self.api_client.patch(
+            f"{self.endpoint}/l2vpn/1.0/a123",
+            json=payload,
+        )
+        assert response.status_code == 400
+
     @patch("requests.delete")
     async def test_delete_l2vpn(self, requests_mock):
         """Test delete a l2vpn."""
@@ -279,6 +333,27 @@ class TestMain:
             f"{self.endpoint}/l2vpn/1.0/a123",
         )
         assert response.status_code == 201
+
+        # test 2: failed to submit request to Kytos
+        requests_mock.return_value.status_code = 400
+        response = await self.api_client.delete(
+            f"{self.endpoint}/l2vpn/1.0/a123",
+        )
+        assert response.status_code == 400
+
+        # test 3: failed to submit request to Kytos - not found
+        requests_mock.return_value.status_code = 404
+        response = await self.api_client.delete(
+            f"{self.endpoint}/l2vpn/1.0/a123",
+        )
+        assert response.status_code == 404
+
+        # test 4: failed to submit request to Kytos - exception
+        requests_mock.side_effect = ValueError("err")
+        response = await self.api_client.delete(
+            f"{self.endpoint}/l2vpn/1.0/a123",
+        )
+        assert response.status_code == 400
 
     @patch("requests.post")
     async def test_create_l2vpn_old_api(self, requests_mock):
@@ -508,3 +583,19 @@ class TestMain:
         )
         assert response.status_code == 200
         assert response.json() == get_evc_converted()
+
+        # test 2: failed to get EVCs from mef_eline
+        req_get_mock.return_value.status_code = 404
+        response = await self.api_client.request(
+            "GET",
+            f"{self.endpoint}/l2vpn/1.0/88c326c7e70d49",
+        )
+        assert response.status_code == 404
+
+        # test 3: failed to get EVCs - exception
+        req_get_mock.side_effect = ValueError("err")
+        response = await self.api_client.request(
+            "GET",
+            f"{self.endpoint}/l2vpn/1.0/88c326c7e70d49",
+        )
+        assert response.status_code == 400


### PR DESCRIPTION
Fix #89 

### Description of the change

This PR fixes an issue while converting L2VPN format for VLAN range (`start:end`) into Kytos Mef-Eline format (`[[start, end]]` -- before it was `[start, end]` i.e, only a list instead of a list of tuples)

Additionally, this PR leverage the same vlan parser to also benefit the old APIs with the data from new formats