### PR TITLE
Improvements to avoid topology update sending a wrong version to SDX-LC

### DIFF
--- a/main.py
+++ b/main.py
@@ -407,14 +407,16 @@ class Main(KytosNApp):  # pylint: disable=R0904
     @rest("topology/2.0.0", methods=["GET"])
     def get_sdx_topology_v2(self, _request: Request) -> JSONResponse:
         """return sdx topology v2"""
-        if not self._converted_topo.get("nodes"):
-            return JSONResponse({}, status_code=200)
-        return JSONResponse(self._converted_topo)
+        with self._topo_lock:
+            if not self._converted_topo.get("nodes"):
+                return JSONResponse({}, status_code=200)
+            return JSONResponse(self._converted_topo)
 
     @rest("topology/2.0.0", methods=["POST"])
     def send_topology_to_sdxlc(self, _request: Request) -> JSONResponse:
         """Send the topology (v2) to SDX-LC"""
-        self.post_topology_to_sdxlc(self._converted_topo)
+        with self._topo_lock:
+            self.post_topology_to_sdxlc(self._converted_topo)
         return JSONResponse("Operation successful", status_code=200)
 
     @rest("l2vpn/1.0", methods=["POST"])

--- a/settings.py
+++ b/settings.py
@@ -14,7 +14,7 @@ OXPO_URL = "testoxp.net"
 
 # TOPOLOGY_EVENT_WAIT: time to wait while hanlde topology update
 # events to try to group them
-TOPOLOGY_EVENT_WAIT = 5
+TOPOLOGY_EVENT_WAIT = 3
 
 # Kytos mef_eline endpoint for creating L2VPN PTP
 KYTOS_EVC_URL = "http://127.0.0.1:8181/api/kytos/mef_eline/v2/evc/"


### PR DESCRIPTION
Fix #98 

### Description of the changes

- Reduce wait time for topology update by default to 3 sec (to match majority of the end-to-end tests sleep calls)
- using Lock on topology update to avoid race conditions on the converted topology