### PR TITLE
Better handle node name assignment 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,7 @@ Added
 
 Changed
 =======
--
+- Handle case where the switch may not have the metadata.node_name, and data_path could contain invalid chars
 
 Fixed
 =====

--- a/convert_topology.py
+++ b/convert_topology.py
@@ -202,7 +202,7 @@ class ParseConvertTopology:
         if "node_name" in switch["metadata"]:
             return switch["metadata"]["node_name"][:30]
         if len(switch["data_path"]) <= 30:
-            return switch["data_path"]
+            return re.sub("[^A-Za-z0-9_.,/-]", "", switch["data_path"])
         return switch["dpid"].replace(":", "-")
 
     def get_sdx_node(self, kytos_node: dict) -> dict:
@@ -211,10 +211,7 @@ class ParseConvertTopology:
         and list of ports."""
         sdx_node = {}
 
-        if "node_name" in kytos_node["metadata"]:
-            sdx_node["name"] = kytos_node["metadata"]["node_name"]
-        else:
-            sdx_node["name"] = kytos_node["data_path"]
+        sdx_node["name"] = self.get_kytos_node_name(kytos_node["dpid"])
 
         sdx_node["id"] = f"urn:sdx:node:{self.oxp_url}:{sdx_node['name']}"
 


### PR DESCRIPTION
Fix #100 

## Description of the change

See CHANGELOG

## Local tests

End-to-end tests using this branch:

```
$ git diff docker-compose.yml
diff --git a/docker-compose.yml b/docker-compose.yml
index 8b430f2..54d5cfd 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./kytos-sdx:/src/kytos-sdx
     depends_on:
       mongo:
         condition: service_healthy
@@ -47,6 +48,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./kytos-sdx:/src/kytos-sdx
     depends_on:
       mongo:
         condition: service_healthy
@@ -68,6 +70,7 @@ services:
       - .env
     volumes:
       - .:/sdx-end-to-end-tests
+      - ./kytos-sdx:/src/kytos-sdx
     depends_on:
       mongo:
         condition: service_healthy
$ cd kytos-sdx/
kytos-sdx$ git log -1
commit 8c20a039ed9f5a1bd75cdd507d4afd72c29be5eb (HEAD -> fix/issue_100, origin/fix/issue_100)
Author: Italo Valcy <italovalcy@gmail.com>
Date:   Thu May 21 17:21:55 2026 -0300

    update CHANGELOG.rst
$ docker compose exec -it mininet python3 -m pytest tests/
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-7.2.1, pluggy-1.0.0+repack
rootdir: /sdx-end-to-end-tests
plugins: unordered-0.7.0
collected 104 items

tests/test_01_topology.py .....                                          [  4%]
tests/test_05_l2vpn.py ........                                          [ 12%]
tests/test_06_l2vpn_return_codes.py ..................................   [ 45%]
tests/test_07_l2vpn_return_codes.py .......................              [ 67%]
tests/test_08_l2vpn_return_codes.py ......                               [ 73%]
tests/test_20_use_case_topology.py Xx.x.xx..xxxxxxxx.x.                  [ 92%]
tests/test_21_use_case_topology.py x.xXx                                 [ 97%]
tests/test_99_topology_big_changes.py ...                                [100%]

------------------------------- start/stop times -------------------------------
============ 86 passed, 16 xfailed, 2 xpassed in 2338.69s (0:38:58) ============```